### PR TITLE
feat: add indexer cli (#19)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2268,6 +2268,12 @@
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "peer": true
     },
+    "node_modules/@types/mime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
+      "dev": true
+    },
     "node_modules/@types/mysql": {
       "version": "2.15.21",
       "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.21.tgz",
@@ -4062,6 +4068,10 @@
         "node": ">=8"
       }
     },
+    "node_modules/indexer": {
+      "resolved": "packages/indexer",
+      "link": true
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4070,10 +4080,6 @@
         "once": "^1.3.0",
         "wrappy": "1"
       }
-    },
-    "node_modules/ingestion": {
-      "resolved": "packages/ingestion",
-      "link": true
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -9536,8 +9542,53 @@
         "typescript": "^5.1.6"
       }
     },
+    "packages/indexer": {
+      "version": "1.0.0",
+      "dependencies": {
+        "@azure/identity": "^3.3.0",
+        "@azure/monitor-opentelemetry": "^1.0.0-beta.2",
+        "@azure/search-documents": "^12.0.0-beta.3",
+        "@azure/storage-blob": "^12.15.0",
+        "@dqbd/tiktoken": "^1.0.7",
+        "@fastify/autoload": "^5.0.0",
+        "@fastify/cors": "^8.3.0",
+        "@fastify/multipart": "^7.7.3",
+        "@fastify/sensible": "^5.0.0",
+        "@fastify/type-provider-json-schema-to-ts": "^2.2.2",
+        "commander": "^11.0.0",
+        "dotenv": "^16.3.1",
+        "fastify": "^4.22.2",
+        "fastify-cli": "^5.7.0",
+        "fastify-plugin": "^4.0.0",
+        "mime": "^3.0.0",
+        "openai": "^4.4.0"
+      },
+      "bin": {
+        "index-files": "bin/index-files.js"
+      },
+      "devDependencies": {
+        "@types/mime": "^3.0.1",
+        "@types/node": "^18.0.0",
+        "@types/tap": "^15.0.5",
+        "concurrently": "^8.2.0",
+        "fastify-tsconfig": "^1.0.1",
+        "pino-pretty": "^10.2.0",
+        "tap": "^16.1.0",
+        "ts-node": "^10.4.0",
+        "typescript": "^5.1.6"
+      }
+    },
+    "packages/indexer/node_modules/commander": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
+      "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "packages/ingestion": {
       "version": "1.0.0",
+      "extraneous": true,
       "dependencies": {
         "@azure/identity": "^3.3.0",
         "@azure/monitor-opentelemetry": "^1.0.0-beta.2",

--- a/packages/indexer/bin/index-files.js
+++ b/packages/indexer/bin/index-files.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import { execSync } from 'node:child_process';
+import { run } from '../dist/lib/cli.js';
+
+if (!(process.env.NODE_OPTIONS ?? '').includes('--no-warnings')) {
+  // Silence experimental warnings
+  execSync(process.argv.join(' '), {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ''} --no-warnings`,
+    },
+  });
+} else {
+  run(process.argv);
+}

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -8,6 +8,9 @@
   "directories": {
     "test": "test"
   },
+  "bin": {
+    "index-files": "./bin/index-files.js"
+  },
   "scripts": {
     "start": "fastify start -l info dist/app.js -p 3001",
     "test:unit": "npm run build && tsc -p test/tsconfig.json && tap --ts \"test-dist/test/**/*.test.js\"",
@@ -32,13 +35,16 @@
     "@fastify/multipart": "^7.7.3",
     "@fastify/sensible": "^5.0.0",
     "@fastify/type-provider-json-schema-to-ts": "^2.2.2",
+    "commander": "^11.0.0",
     "dotenv": "^16.3.1",
     "fastify": "^4.22.2",
     "fastify-cli": "^5.7.0",
     "fastify-plugin": "^4.0.0",
+    "mime": "^3.0.0",
     "openai": "^4.4.0"
   },
   "devDependencies": {
+    "@types/mime": "^3.0.1",
     "@types/node": "^18.0.0",
     "@types/tap": "^15.0.5",
     "concurrently": "^8.2.0",

--- a/packages/indexer/src/lib/cli.ts
+++ b/packages/indexer/src/lib/cli.ts
@@ -1,0 +1,89 @@
+import process from 'node:process';
+import fs from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { join, dirname, extname } from 'node:path';
+import { OptionValues, program } from 'commander';
+import * as dotenv from 'dotenv';
+import mime from 'mime/lite.js';
+
+export interface IndexFilesOptions {
+  indexerUrl: string;
+  indexName?: string;
+  category?: string;
+  uploadToBlobStorage: boolean;
+  useVectors: boolean;
+  wait: boolean;
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export async function run(args: string[] = process.argv) {
+  dotenv.config();
+
+  const file = await fs.readFile(join(__dirname, '../../package.json'), 'utf8');
+  const pkg = JSON.parse(file) as Record<string, string>;
+
+  program
+    .name('index-files')
+    .arguments('<files...>')
+    .description('CLI utility to send files to an indexer service instance')
+    .option('-u, --indexer-url <url>', 'The indexer service URL', 'http://localhost:3001')
+    .option('-i, --index-name <name>', 'The name of the target index', process.env.AZURE_SEARCH_INDEX)
+    .option('-c, --category <name>', 'Set document category')
+    .option('-w, --wait', 'Wait for the indexer to finish processing the files', false)
+    .option('--no-upload', 'Disable uploading files to a blob storage container')
+    .option('--no-vectors', 'Disable vectors generation for the files')
+    .version(pkg.version, '-v, --version', 'Show the current version')
+    .showHelpAfterError()
+    .action(async (files: string[], options: OptionValues) => {
+      const { indexerUrl, indexName, upload, vectors, wait } = options;
+      await indexFiles(files, {
+        indexerUrl,
+        indexName,
+        uploadToBlobStorage: upload,
+        useVectors: vectors,
+        wait,
+      });
+    });
+  program.parse(args);
+}
+
+export async function indexFiles(files: string[], options: IndexFilesOptions) {
+  try {
+    if (!options.indexName) {
+      throw new Error('Index name is required');
+    }
+    console.log(`Indexing ${files.length} file(s)...`);
+    const promises = files.map(async (file) => indexFile(file, options));
+    await Promise.all(promises);
+  } catch (_error: unknown) {
+    const error = _error as Error;
+    console.error(`Error indexing files: ${error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+async function indexFile(file: string, options: IndexFilesOptions) {
+  console.log(`Indexing file "${file}"...`);
+  const { indexerUrl, indexName, category, uploadToBlobStorage, useVectors, wait } = options;
+  const formData = new FormData();
+  const fileIndexOptions = {
+    category,
+    uploadToBlobStorage,
+    useVectors,
+    wait,
+  };
+  const type = mime.getType(extname(file)) ?? 'application/octet-stream';
+  const fileData = await fs.readFile(file);
+  formData.append('file', new Blob([fileData], { type }), file);
+  formData.append('options', JSON.stringify(fileIndexOptions));
+  const response = await fetch(`${indexerUrl}/indexes/${indexName}/files`, {
+    method: 'POST',
+    body: formData,
+  });
+  if (!response.ok) {
+    const errorDetails = await response.json();
+    throw new Error(`Error indexing file "${file}": ${errorDetails.message}`);
+  }
+  console.log(`File "${file}" indexed successfully`);
+}

--- a/packages/indexer/src/lib/index.ts
+++ b/packages/indexer/src/lib/index.ts
@@ -1,4 +1,6 @@
 export * from './util/index.js';
+export * from './cli.js';
 export * from './blob-storage.js';
 export * from './document-processor.js';
 export * from './indexer.js';
+export * from './model-limits.js';


### PR DESCRIPTION
This PR introduces the `index-files` CLI tool, to upload files to the indexer service. This tool is meant as a test tool, and will also be used in a post-deploy script to populate the knowledge store used in the API.