### PR TITLE
feat: make it easier to use gpt4

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,11 @@ Technology comparison:
 <details><a id="switch-gpt4"></a>
 <summary>How do you use GPT-4 with this sample?</summary>
 
-In `infra/main.bicep`, change `chatGptModelName` to 'gpt-4' instead of 'gpt-35-turbo'. You may also need to adjust the capacity above that line depending on how much TPM your account is allowed.
+Run these commands:
+```bash
+azd env set AZURE_OPENAI_CHATGPT_MODEL gpt-4
+```
+You may also need to adjust the capacity in `infra/main.bicep` file, depending on how much TPM your account is allowed.
 
 </details>
 <details><a id="chat-ask-diff"></a>

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -64,8 +64,8 @@ param formRecognizerSkuName string = 'S0'
 
 param chatGptDeploymentName string // Set in main.parameters.json
 param chatGptDeploymentCapacity int = 30
-param chatGptModelName string = 'gpt-35-turbo'
-param chatGptModelVersion string = '0613'
+param chatGptModelName string // Set in main.parameters.json
+param chatGptModelVersion string // Set in main.parameters.json
 param embeddingDeploymentName string = 'embedding'
 param embeddingDeploymentCapacity int = 30
 param embeddingModelName string = 'text-embedding-ada-002'

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -62,6 +62,12 @@
     "storageSkuName": {
       "value": "${AZURE_STORAGE_SKU=Standard_LRS}"
     },
+    "chatGptModelName": {
+      "value": "${AZURE_OPENAI_CHATGPT_MODEL=gpt-35-turbo}"
+    },
+    "chatGptModelVersion": {
+      "value": "${AZURE_OPENAI_CHATGPT_MODEL_VERSION=0613}"
+    },
     "chatGptDeploymentName": {
       "value": "${AZURE_OPENAI_CHATGPT_DEPLOYMENT=chat}"
     },


### PR DESCRIPTION
 The model won't deploy with gpt4, but I don't understand why:
 ```
 SpecialFeatureOrQuotaIdRequired: The current subscription does not have feature required by this model 'Format: OpenAI, Name: gpt-4, Version: 0613' and SKU 'Standard'.
```
Tried in both my subscription (which has GPT4 enabled) and the CDA sub, same error. 
Model is available in the default region eastus2 (https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models#model-summary-table-and-region-availability) so it's not that.