### PR TITLE
fix: Handle errors from input filtering better

### DIFF
--- a/packages/chat-component/src/config/global-config.js
+++ b/packages/chat-component/src/config/global-config.js
@@ -34,7 +34,7 @@ const globalConfig = {
   LOADING_INDICATOR_TEXT: 'Please wait. We are searching and generating an answer...',
   // API ERROR HANDLING IN UI
   API_ERROR_MESSAGE: 'Sorry, we are having some problems. Please try again later.',
-  INVALID_REQUEST_ERROR: 'Sorry, the app cannot process the request. Please modify your question and try again.',
+  INVALID_REQUEST_ERROR: 'Unable to generate answer for this query. Please modify your question and try again.',
   // Config pertaining the response format
   THOUGHT_PROCESS_LABEL: 'Thought Process',
   SUPPORT_CONTEXT_LABEL: 'Support Context',

--- a/packages/chat-component/src/config/global-config.js
+++ b/packages/chat-component/src/config/global-config.js
@@ -34,7 +34,7 @@ const globalConfig = {
   LOADING_INDICATOR_TEXT: 'Please wait. We are searching and generating an answer...',
   // API ERROR HANDLING IN UI
   API_ERROR_MESSAGE: 'Sorry, we are having some problems. Please try again later.',
-  API_BAD_REQUEST_ERROR: 'Sorry, the app cannot process the request. Please modify your question and try again.',
+  INVALID_REQUEST_ERROR: 'Sorry, the app cannot process the request. Please modify your question and try again.',
   // Config pertaining the response format
   THOUGHT_PROCESS_LABEL: 'Thought Process',
   SUPPORT_CONTEXT_LABEL: 'Support Context',

--- a/packages/chat-component/src/config/global-config.js
+++ b/packages/chat-component/src/config/global-config.js
@@ -34,6 +34,7 @@ const globalConfig = {
   LOADING_INDICATOR_TEXT: 'Please wait. We are searching and generating an answer...',
   // API ERROR HANDLING IN UI
   API_ERROR_MESSAGE: 'Sorry, we are having some problems. Please try again later.',
+  API_BAD_REQUEST_ERROR: 'Sorry, the app cannot process the request. Please modify your question and try again.',
   // Config pertaining the response format
   THOUGHT_PROCESS_LABEL: 'Thought Process',
   SUPPORT_CONTEXT_LABEL: 'Support Context',

--- a/packages/chat-component/src/core/http/index.ts
+++ b/packages/chat-component/src/core/http/index.ts
@@ -1,3 +1,5 @@
+import { ChatResponseError } from '../../utils/index.js';
+
 export async function callHttpApi(
   { question, type, approach, overrides }: ChatRequestOptions,
   { method, url, stream, signal }: ChatHttpOptions,
@@ -37,7 +39,7 @@ export async function getAPIResponse(
   }
   const parsedResponse: BotResponse = await response.json();
   if (response.status > 299 || !response.ok) {
-    throw new Error(response.statusText) || 'API Response Error';
+    throw new ChatResponseError(response.statusText, response.status) || 'API Response Error';
   }
   return parsedResponse;
 }

--- a/packages/chat-component/src/core/parser/index.ts
+++ b/packages/chat-component/src/core/parser/index.ts
@@ -38,13 +38,13 @@ export async function parseStreamedMessages({
     }
 
     if (chunk.error) {
-      throw new ChatResponseError(chunk.message, chunk.code);
+      throw new ChatResponseError(chunk.message, chunk.statusCode);
     }
 
     // content is filtered during the output streaming
     // https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/content-filter?tabs=javascrit
     if (chunk.choices[0].finish_reason === 'content_filter') {
-      throw new ChatResponseError('Content filter triggered', 'content_filter');
+      throw new ChatResponseError('Content filtered', 400);
     }
 
     const { content, context } = chunk.choices[0].delta;

--- a/packages/chat-component/src/core/parser/index.ts
+++ b/packages/chat-component/src/core/parser/index.ts
@@ -1,3 +1,4 @@
+import { ChatResponseError } from '../../utils/index.js';
 import { createReader, readStream } from '../stream/index.js';
 
 export async function parseStreamedMessages({
@@ -36,6 +37,9 @@ export async function parseStreamedMessages({
       return result;
     }
 
+    if (chunk.statusCode && chunk.statusCode > 299) {
+      throw new ChatResponseError('API chunk has an error', chunk.statusCode);
+    }
     const { content, context } = chunk.choices[0].delta;
     if (context?.data_points) {
       result.data_points = context.data_points ?? [];

--- a/packages/chat-component/src/core/parser/index.ts
+++ b/packages/chat-component/src/core/parser/index.ts
@@ -15,7 +15,7 @@ export async function parseStreamedMessages({
   onCancel: () => void;
 }) {
   const reader = createReader(apiResponseBody);
-  const chunks = readStream<BotResponseChunk>(reader);
+  const chunks = readStream<BotResponseChunk | BotResponseError>(reader);
 
   const streamedMessageRaw: string[] = [];
   const stepsBuffer: string[] = [];
@@ -38,8 +38,9 @@ export async function parseStreamedMessages({
     }
 
     if (chunk.statusCode && chunk.statusCode > 299) {
-      throw new ChatResponseError('API chunk has an error', chunk.statusCode);
+      throw new ChatResponseError(chunk.message, chunk.statusCode);
     }
+
     const { content, context } = chunk.choices[0].delta;
     if (context?.data_points) {
       result.data_points = context.data_points ?? [];

--- a/packages/chat-component/src/core/parser/index.ts
+++ b/packages/chat-component/src/core/parser/index.ts
@@ -37,8 +37,14 @@ export async function parseStreamedMessages({
       return result;
     }
 
-    if (chunk.statusCode && chunk.statusCode > 299) {
-      throw new ChatResponseError(chunk.message, chunk.statusCode);
+    if (chunk.error) {
+      throw new ChatResponseError(chunk.message, chunk.code);
+    }
+
+    // content is filtered during the output streaming
+    // https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/content-filter?tabs=javascrit
+    if (chunk.choices[0].finish_reason === 'content_filter') {
+      throw new ChatResponseError('Content filter triggered', 'content_filter');
     }
 
     const { content, context } = chunk.choices[0].delta;

--- a/packages/chat-component/src/main.ts
+++ b/packages/chat-component/src/main.ts
@@ -377,10 +377,7 @@ export class ChatComponent extends LitElement {
           ...this.chatThread,
           {
             error: {
-              message:
-                chatError?.code === 'content_filter' || chatError?.code === 400
-                  ? globalConfig.INVALID_REQUEST_ERROR
-                  : globalConfig.API_ERROR_MESSAGE,
+              message: chatError?.code === 400 ? globalConfig.INVALID_REQUEST_ERROR : globalConfig.API_ERROR_MESSAGE,
             },
             text: [],
             timestamp: getTimestamp(),

--- a/packages/chat-component/src/main.ts
+++ b/packages/chat-component/src/main.ts
@@ -378,7 +378,9 @@ export class ChatComponent extends LitElement {
           {
             error: {
               message:
-                chatError?.statusCode === 400 ? globalConfig.API_BAD_REQUEST_ERROR : globalConfig.API_ERROR_MESSAGE,
+                chatError?.code === 'content_filter' || chatError?.code === 400
+                  ? globalConfig.INVALID_REQUEST_ERROR
+                  : globalConfig.API_ERROR_MESSAGE,
             },
             text: [],
             timestamp: getTimestamp(),

--- a/packages/chat-component/src/style.ts
+++ b/packages/chat-component/src/style.ts
@@ -19,6 +19,7 @@ export const mainStyle = css`
     --accent-lighter: #f6d0d0;
     --accent-contrast: #7d3c71;
     --error-color: #8a0000;
+    --error-color-background: rgb(253, 231, 233);
   }
   :host([data-theme='dark']]) {
     display: block;
@@ -34,7 +35,8 @@ export const mainStyle = css`
     --accent-light: #e6fbf7;
     --accent-lighter: #f6d0d0;
     --accent-contrast: #7d3c71;
-    --error-color: #8a0000;
+    --error-color: rgb(243, 242, 241);
+    --error-color-background: rgb(68, 39, 38);
   }
   html {
     scroll-behavior: smooth;
@@ -433,6 +435,7 @@ export const mainStyle = css`
     border: 3px solid var(--error-color);
     color: var(--error-color);
     padding: 20px;
+    background: var(--error-color-background);
   }
   .chat__txt.user-message {
     background: linear-gradient(to left, var(--accent-contrast), var(--accent-high));

--- a/packages/chat-component/src/types.d.ts
+++ b/packages/chat-component/src/types.d.ts
@@ -93,7 +93,7 @@ declare type BotResponseMessage = Message & {
 };
 
 declare interface BotResponseError {
-  error?: string;
-  statusCode?: number;
-  message?: string;
+  error: string;
+  code: string;
+  message: string;
 }

--- a/packages/chat-component/src/types.d.ts
+++ b/packages/chat-component/src/types.d.ts
@@ -17,6 +17,9 @@ declare interface ChatThreadEntry {
   followupQuestions?: string[];
   isUserMessage: boolean;
   timestamp: string;
+  error?: {
+    message: string;
+  };
 }
 
 declare interface Citation {
@@ -73,6 +76,7 @@ declare interface BotResponse {
 }
 
 declare interface BotResponseChunk {
+  statusCode?: number;
   choices: Array<{
     index: number;
     delta: Partial<BotResponseMessage>;

--- a/packages/chat-component/src/types.d.ts
+++ b/packages/chat-component/src/types.d.ts
@@ -93,6 +93,7 @@ declare type BotResponseMessage = Message & {
 };
 
 declare interface BotResponseError {
+  statusCode: number;
   error: string;
   code: string;
   message: string;

--- a/packages/chat-component/src/types.d.ts
+++ b/packages/chat-component/src/types.d.ts
@@ -76,7 +76,6 @@ declare interface BotResponse {
 }
 
 declare interface BotResponseChunk {
-  statusCode?: number;
   choices: Array<{
     index: number;
     delta: Partial<BotResponseMessage>;
@@ -92,3 +91,9 @@ declare type BotResponseMessage = Message & {
   };
   session_state?: Record<string, any>;
 };
+
+declare interface BotResponseError {
+  error?: string;
+  statusCode?: number;
+  message?: string;
+}

--- a/packages/chat-component/src/utils/index.ts
+++ b/packages/chat-component/src/utils/index.ts
@@ -76,3 +76,13 @@ export function getTimestamp() {
     hour12: true,
   });
 }
+
+// Creates a new chat message error
+export class ChatResponseError extends Error {
+  statusCode?: number;
+
+  constructor(message: string, statusCode?: number) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+}

--- a/packages/chat-component/src/utils/index.ts
+++ b/packages/chat-component/src/utils/index.ts
@@ -79,10 +79,10 @@ export function getTimestamp() {
 
 // Creates a new chat message error
 export class ChatResponseError extends Error {
-  statusCode?: number;
+  code?: string;
 
-  constructor(message: string, statusCode?: number) {
+  constructor(message: string, code?: string) {
     super(message);
-    this.statusCode = statusCode;
+    this.code = code;
   }
 }

--- a/packages/chat-component/src/utils/index.ts
+++ b/packages/chat-component/src/utils/index.ts
@@ -79,9 +79,9 @@ export function getTimestamp() {
 
 // Creates a new chat message error
 export class ChatResponseError extends Error {
-  code?: string;
+  code?: number;
 
-  constructor(message: string, code?: string) {
+  constructor(message: string, code?: number) {
     super(message);
     this.code = code;
   }

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -11,6 +11,15 @@ In the project directory, you can run:
 To start the app in dev mode.\
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
+To target the deployed resources you need to create an `.env` file in the package.
+You can create and populate the .env file using
+
+```
+azd env get-values > .env
+```
+
+You will also need to authenticate to Azure using `az login` before calling the APIs.
+
 ### `npm start`
 
 For production mode

--- a/packages/search/src/routes/root.ts
+++ b/packages/search/src/routes/root.ts
@@ -100,9 +100,9 @@ const root: FastifyPluginAsync = async (_fastify, _options): Promise<void> => {
           return await chatApproach.run(messages, (context as any) ?? {});
         }
       } catch (_error: unknown) {
-        const error = _error as Error;
+        const error = _error as Error & { status?: number };
         fastify.log.error(error);
-        return reply.internalServerError(error.message);
+        return error.status === 400 ? reply.badRequest(error.message) : reply.internalServerError(error.message);
       }
     },
   });
@@ -143,9 +143,9 @@ const root: FastifyPluginAsync = async (_fastify, _options): Promise<void> => {
           return await askApproach.run(messages[0].content, (context as any) ?? {});
         }
       } catch (_error: unknown) {
-        const error = _error as Error;
+        const error = _error as Error & { status?: number };
         fastify.log.error(error);
-        return reply.internalServerError(error.message);
+        return error.status === 400 ? reply.badRequest(error.message) : reply.internalServerError(error.message);
       }
     },
   });

--- a/packages/search/src/routes/root.ts
+++ b/packages/search/src/routes/root.ts
@@ -100,10 +100,10 @@ const root: FastifyPluginAsync = async (_fastify, _options): Promise<void> => {
           return await chatApproach.run(messages, (context as any) ?? {});
         }
       } catch (_error: unknown) {
-        const error = _error as Error & { status?: number };
+        const error = _error as Error & { error?: any; status?: number };
         fastify.log.error(error);
-        if (error.status) {
-          return reply.code(error.status).send(error);
+        if (error.error) {
+          return reply.code(error.status ?? 500).send(error);
         }
 
         return reply.internalServerError(error.message);
@@ -147,10 +147,10 @@ const root: FastifyPluginAsync = async (_fastify, _options): Promise<void> => {
           return await askApproach.run(messages[0].content, (context as any) ?? {});
         }
       } catch (_error: unknown) {
-        const error = _error as Error & { status?: number };
+        const error = _error as Error & { error?: any; status?: number };
         fastify.log.error(error);
-        if (error.status) {
-          return reply.code(error.status).send(error);
+        if (error.error) {
+          return reply.code(error.status ?? 500).send(error);
         }
 
         return reply.internalServerError(error.message);

--- a/packages/search/src/routes/root.ts
+++ b/packages/search/src/routes/root.ts
@@ -102,7 +102,11 @@ const root: FastifyPluginAsync = async (_fastify, _options): Promise<void> => {
       } catch (_error: unknown) {
         const error = _error as Error & { status?: number };
         fastify.log.error(error);
-        return error.status === 400 ? reply.badRequest(error.message) : reply.internalServerError(error.message);
+        if (error.status) {
+          return reply.code(error.status).send(error);
+        }
+
+        return reply.internalServerError(error.message);
       }
     },
   });
@@ -145,7 +149,11 @@ const root: FastifyPluginAsync = async (_fastify, _options): Promise<void> => {
       } catch (_error: unknown) {
         const error = _error as Error & { status?: number };
         fastify.log.error(error);
-        return error.status === 400 ? reply.badRequest(error.message) : reply.internalServerError(error.message);
+        if (error.status) {
+          return reply.code(error.status).send(error);
+        }
+
+        return reply.internalServerError(error.message);
       }
     },
   });

--- a/tests/e2e/hars/error-chat-response-stream.har
+++ b/tests/e2e/hars/error-chat-response-stream.har
@@ -1,0 +1,74 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "Playwright",
+      "version": "1.39.0"
+    },
+    "browser": {
+      "name": "chromium",
+      "version": "119.0.6045.9"
+    },
+    "entries": [
+      {
+        "startedDateTime": "2023-10-25T00:27:07.983Z",
+        "time": 4348.057,
+        "request": {
+          "method": "POST",
+          "url": "http://localhost:5173/chat",
+          "httpVersion": "HTTP/2.0",
+          "cookies": [],
+          "headers": [
+            { "name": ":authority", "value": "http://localhost:5173" },
+            { "name": ":method", "value": "POST" },
+            { "name": ":path", "value": "/chat" },
+            { "name": ":scheme", "value": "http" },
+            { "name": "accept", "value": "*/*" },
+            { "name": "accept-encoding", "value": "gzip, deflate, br" },
+            { "name": "accept-language", "value": "en-US" },
+            { "name": "content-length", "value": "437" },
+            { "name": "content-type", "value": "application/json" },
+            { "name": "origin", "value": "http://localhost:5173" },
+            { "name": "sec-fetch-dest", "value": "empty" },
+            { "name": "sec-fetch-mode", "value": "cors" },
+            { "name": "sec-fetch-site", "value": "cross-site" },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.6045.9 Safari/537.36"
+            }
+          ],
+          "queryString": [],
+          "headersSize": -1,
+          "bodySize": -1,
+          "postData": {
+            "mimeType": "application/json",
+            "text": "{\"messages\":[{\"content\":\"How to search and book rentals?\",\"role\":\"user\"}],\"context\":{\"retrieval_mode\":\"hybrid\",\"semantic_ranker\":true,\"semantic_captions\":false,\"suggest_followup_questions\":true,\"retrievalMode\":\"hybrid\",\"top\":3,\"useSemanticRanker\":true,\"useSemanticCaptions\":false,\"excludeCategory\":\"\",\"promptTemplate\":\"\",\"promptTemplatePrefix\":\"\",\"promptTemplateSuffix\":\"\",\"suggestFollowupQuestions\":true,\"approach\":\"rrr\"},\"stream\":true}",
+            "params": []
+          }
+        },
+        "response": {
+          "status": 200,
+          "statusText": "",
+          "httpVersion": "HTTP/2.0",
+          "cookies": [],
+          "headers": [
+            { "name": "access-control-allow-origin", "value": "http://localhost:5173" },
+            { "name": "content-type", "value": "application/x-ndjson" },
+            { "name": "date", "value": "Wed, 25 Oct 2023 00:27:10 GMT" },
+            { "name": "vary", "value": "Origin" }
+          ],
+          "content": {
+            "size": -1,
+            "mimeType": "application/x-ndjson",
+            "text": "{\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\",\"role\":\"assistant\",\"context\":{\"data_points\":[],\"thoughts\":\"Here's how to do it: 1.\"}},\"finish_reason\":null}],\"object\":\"chat.completion.chunk\"}\n{\"choices\":[{\"index\":0,\"delta\":{\"content\":\"To\",\"role\":\"assistant\",\"context\":{}},\"finish_reason\":null}],\"object\":\"chat.completion.chunk\"}\n{\"choices\":[{\"index\":0,\"delta\":{\"content\":\" search\",\"role\":\"assistant\",\"context\":{}},\"finish_reason\":null}],\"object\":\"chat.completion.chunk\"}\n{\"choices\":[{\"index\":0,\"delta\":{\"content\":\" and\",\"role\":\"assistant\",\"context\":{}},\"finish_reason\":null}],\"object\":\"chat.completion.chunk\"}\n{\"choices\":[{\"index\":0,\"delta\":{\"content\":\" book\",\"role\":\"assistant\",\"context\":{}},\"finish_reason\":null}],\"object\":\"chat.completion.chunk\"}\n{\"choices\":[{\"index\":0,\"delta\":{\"content\":\" rentals\",\"role\":\"assistant\",\"context\":{}},\"finish_reason\":\"content_filter\"}],\"object\":\"chat.completion.chunk\"}\n{\"choices\":[{\"index\":0,\"delta\":{\"content\":\" on\",\"role\":\"assistant\",\"context\":{}},\"finish_reason\":null}],\"object\":\"chat.completion.chunk\"}\n{\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\",\"role\":\"assistant\",\"context\":{}},\"finish_reason\":\"stop\"}],\"object\":\"chat.completion.chunk\"}\n"
+          },
+          "headersSize": -1,
+          "bodySize": -1,
+          "redirectURL": ""
+        },
+        "cache": {},
+        "timings": { "send": -1, "wait": -1, "receive": 4348.057 }
+      }
+    ]
+  }
+}

--- a/tests/e2e/webapp.spec.ts
+++ b/tests/e2e/webapp.spec.ts
@@ -127,9 +127,9 @@ test.describe('default', () => {
       }),
     );
 
-    await expect(page.locator('.loading-skeleton')).not.toBeVisible();
+    await expect(page.locator('.loading-text')).not.toBeVisible();
     await page.getByTestId('submit-question-button').click();
-    await expect(page.locator('.loading-skeleton')).toBeVisible();
+    await expect(page.locator('.loading-text')).toBeVisible();
     await expect(page.getByTestId('question-input')).not.toBeEnabled();
   });
 });

--- a/tests/e2e/webapp.spec.ts
+++ b/tests/e2e/webapp.spec.ts
@@ -181,6 +181,26 @@ test.describe('errors', () => {
     await expect(page.locator('.chat__txt.error')).toContainText('Please modify your question and try again');
   });
 
+  test('stream: content filter during stream', async ({ page }) => {
+    await page.goto('/');
+    await page.getByTestId('default-question').nth(0).click();
+
+    await page.routeFromHAR('./tests/e2e/hars/error-chat-response-stream.har', {
+      url: '/chat',
+      update: false,
+    });
+
+    await page.getByTestId('submit-question-button').click();
+    await expect(page.locator('.chat__txt.error')).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator('.chat__txt.error')).toContainText('Please modify your question and try again');
+
+    // make sure the content is there for all text entries including some of the streamed content
+    const chatContent = page.locator('.chat__txt--entry');
+    await expect(chatContent).toHaveCount(2);
+    await expect(chatContent.nth(0)).not.toHaveText('');
+    await expect(chatContent.nth(1)).not.toHaveText('');
+  });
+
   test('no stream: on server failure', async ({ page }) => {
     await page.goto('/');
     await page.getByTestId('default-question').nth(0).click();


### PR DESCRIPTION
## Purpose

Handle the content filtered errors from Open AI better. For reference: https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/content-filter

Changes include: 
- Handling bad request errors separately from internal server errors
- Handle content filtering in the middle of streamed output. 
- Fix bug where error message is not sticky to the user input but is only shown once. 
- Fix bug where loading indicator does not show up after an error

## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

