### PR TITLE
Use javascript-node:18-bullseye for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,10 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
 {
-  "name": "Node.js",
+  "name": "Azure Search OpenAI Js",
 
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:18-bullseye",
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {


### PR DESCRIPTION
javascript-node:18-bullseye should fix this issue: https://github.com/Azure/azure-dev/issues/2942