### PR TITLE
fix: only show voice input if reset input is not set

### DIFF
--- a/packages/chat-component/src/main.ts
+++ b/packages/chat-component/src/main.ts
@@ -663,7 +663,7 @@ export class ChatComponent extends LitElement {
                   autocomplete="off"
                   @keyup="${this.handleOnInputChange}"
                 />
-                ${this.showVoiceInput
+                ${this.showVoiceInput && !this.isResetInput
                   ? html` <button
                       title="${this.enableVoiceListening
                         ? globalConfig.CHAT_VOICE_REC_BUTTON_LABEL_TEXT


### PR DESCRIPTION
## Purpose

Fix for #132 where voice input overlaps with reset input. Only shows voice input if there is no reset button. 

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->

```
[ ] Yes
[X] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

