### PR TITLE
Pass the selected approach to the chat component and to the api call

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
     "ghcr.io/devcontainers/features/node:1": {
       "version": "18"
     },
-    "ghcr.io/devcontainers/features/docker-in-docker:2.9.0": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "version": 20,
       "moby": "false"
     },

--- a/packages/chat-component/src/components/chat-component.ts
+++ b/packages/chat-component/src/components/chat-component.ts
@@ -72,6 +72,9 @@ export class ChatComponent extends LitElement {
   @property({ type: String, attribute: 'data-use-stream', converter: (value) => value?.toLowerCase() === 'true' })
   useStream: boolean = chatHttpOptions.stream;
 
+  @property({ type: String, attribute: 'data-approach' })
+  approach = requestOptions.approach;
+
   @property({ type: String, attribute: 'data-overrides', converter: (value) => JSON.parse(value || '{}') })
   overrides: RequestOverrides = {};
 
@@ -199,6 +202,7 @@ export class ChatComponent extends LitElement {
     await this.chatController.generateAnswer(
       {
         ...requestOptions,
+        approach: this.approach,
         overrides: {
           ...requestOptions.overrides,
           ...this.overrides,

--- a/packages/webapp/src/pages/oneshot/OneShot.tsx
+++ b/packages/webapp/src/pages/oneshot/OneShot.tsx
@@ -22,7 +22,7 @@ import { toolTipText, toolTipTextCalloutProps } from '../../i18n/tooltips.js';
 
 export function Component(): JSX.Element {
   const [isConfigPanelOpen, setIsConfigPanelOpen] = useState(false);
-  const [approach, setApproach] = useState<Approaches>(Approaches.RetrieveThenRead);
+  const [approach, setApproach] = useState<Approaches>(Approaches.ReadRetrieveRead);
   const [promptTemplate, setPromptTemplate] = useState<string>('');
   const [promptTemplatePrefix, setPromptTemplatePrefix] = useState<string>('');
   const [promptTemplateSuffix, setPromptTemplateSuffix] = useState<string>('');

--- a/packages/webapp/src/pages/oneshot/OneShot.tsx
+++ b/packages/webapp/src/pages/oneshot/OneShot.tsx
@@ -113,7 +113,7 @@ export function Component(): JSX.Element {
           data-interaction-model="ask"
           data-api-url={apiBaseUrl}
           data-use-stream="false"
-          data-approach="rrr"
+          data-approach={approach}
           data-overrides={JSON.stringify(overrides)}
         ></chat-component>
       </div>


### PR DESCRIPTION
### This issue is for a: (mark with an `x`)

```
- [x ] bug report -> please search issues before submitting
- [ ] feature request
- [ ] documentation issue or request
- [ ] regression (a behavior that used to work and stopped in a new release)
```

### Minimal steps to reproduce

> azd auth login
> azd up

> go to static web app
> select any of the default search questions and click the search buttoon
> open the though process
> verify there is text like "[DynamicTool]" in there
> Open the Developer Settings in upper right corner
> Notice the "Retrieve-Then-Read" is selected

The ask-read-retrieve-read is the approach that uses the Dynamic Tool. 

You can try changing the approach in the Developer Settings, but it does not seem to work.

Also the OneShot.tsx file does have the rrr hard-coded.

### Expected/desired behavior

> Change the approach being used when the Developer Setting is changed
