### PR TITLE
Fix error with undefined choices in new conversations

### DIFF
--- a/packages/search/src/lib/approaches/chat-read-retrieve-read.ts
+++ b/packages/search/src/lib/approaches/chat-read-retrieve-read.ts
@@ -107,14 +107,14 @@ export class ChatReadRetrieveRead extends ApproachBase implements ChatApproach {
           {
             index: 0,
             delta: {
-              content: chunk.choices[0].delta.content ?? '',
+              content: chunk.choices[0]?.delta.content ?? '',
               role: 'assistant' as const,
               context: {
                 data_points: id === 0 ? { text: dataPoints } : undefined,
                 thoughts: id === 0 ? thoughts : undefined,
               },
             },
-            finish_reason: chunk.choices[0].finish_reason,
+            finish_reason: chunk.choices[0]?.finish_reason,
           },
         ],
         object: 'chat.completion.chunk' as const,


### PR DESCRIPTION
-Added safe navigation to an object that might be undefined on an empty conversation. -Fixes #201

## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

- Prevents an error in new projects where empty choices are returned because of the lack of context history.

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->

```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

- Test the code
<!-- Add steps to run the tests suite and/or manually test -->

```
Spin up a new project
Validate that the console displays no errors
```

## What to Check

Verify that the following are valid

- A new conversation without prior context should have no error when retrieving the choices.

## Other Information

<!-- Add any other helpful information that may be needed here. -->
