### PR TITLE
fix(bicep): resolve conditional scope error in container registry module

### DIFF
--- a/infra/core/host/container-apps.bicep
+++ b/infra/core/host/container-apps.bicep
@@ -10,6 +10,10 @@ param containerRegistryAdminUserEnabled bool = false
 param logAnalyticsWorkspaceName string
 param applicationInsightsName string = ''
 
+var containerRegistryScope = !empty(containerRegistryResourceGroupName)
+  ? resourceGroup(containerRegistryResourceGroupName)
+  : resourceGroup()
+
 module containerAppsEnvironment 'container-apps-environment.bicep' = {
   name: '${name}-container-apps-environment'
   params: {
@@ -23,7 +27,7 @@ module containerAppsEnvironment 'container-apps-environment.bicep' = {
 
 module containerRegistry 'container-registry.bicep' = {
   name: '${name}-container-registry'
-  scope: !empty(containerRegistryResourceGroupName) ? resourceGroup(containerRegistryResourceGroupName) : resourceGroup()
+  scope: containerRegistryScope
   params: {
     name: containerRegistryName
     location: location


### PR DESCRIPTION
## Purpose
- Fixes an issue where the scope for the containerRegistry module could not be resolved at compile time due to conditional logic.
- Ensures that the scope is always explicitly defined using resourceGroup() or resourceGroup(containerRegistryResourceGroupName) to allow Bicep compilation to succeed.

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->

```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

- Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

- Test the code
```
This error occurs at compile time when you run `azd up`, where the error should look something like below: 
`BCP420: The scope could not be resolved at compile time because the supplied expression is ambiguous or too complex.`

After the above fix, this error should not occur anymore
```

## What to Check

Confirm that `azd up` goes  successfully without the above error

## Other Information

<!-- Add any other helpful information that may be needed here. -->
